### PR TITLE
Fix：‘TypeError: responseCookies.replace is not a function’

### DIFF
--- a/src/cookieShim.js
+++ b/src/cookieShim.js
@@ -43,7 +43,8 @@ const cookieStore = (function () {
         let responseCookies = response.header ? response.header['Set-Cookie'] || response.header['set-cookie'] : ''
         if (responseCookies) {
           // 处理QQ小程序下cookie分隔符问题：https://github.com/charleslo1/weapp-cookie/issues/39
-          responseCookies = responseCookies.replace(/\;([^\s\;]*?(?=\=))/ig, ',$1')
+          // 兼容在ios设备下获取到的set-cookie为数组情况
+          responseCookies = responseCookies.toString().replace(/\;([^\s\;]*?(?=\=))/ig, ',$1')
           // 设置 cookies，以便下次请求带上
           cookieStore.setResponseCookies(responseCookies, domain)
         }


### PR DESCRIPTION
作者你好：
在使用weapp-cookie库中遇到一个问题，已经查询到问题原因并进行兼容处理
是在uniapp项目中使用编译到微信小程序，调用`uploadFile`在ios真机下取到的 `responseCookies`是一个数组，在调用`replace`出错了
![image](https://github.com/charleslo1/weapp-cookie/assets/79572047/e77e69e4-ae52-4082-8194-83b0b5c21ee7)
经过正常调试发现，接口的`response`确实返回了三个`Set-Cookie`，但是在大部分情机型况下responseCookies都是‘字符串+,’拼接好，但在在ios真机下没有进行字符串处理所以我们这里手动调用一下`toString()`就可以了
![image](https://github.com/charleslo1/weapp-cookie/assets/79572047/aecb7812-00b7-49e0-b5ce-604d413e6274)
![image](https://github.com/charleslo1/weapp-cookie/assets/79572047/349e183b-a141-4612-b2ba-70df6fb70e51)
